### PR TITLE
fix AttributeError when no holidays are specified

### DIFF
--- a/businesstime/__init__.py
+++ b/businesstime/__init__.py
@@ -21,6 +21,7 @@ class BusinessTime(object):
         if callable(self.holidays) or self.holidays is None:
             self._holidaysGeneratorStart = None
             self._holidaysGenerator = None
+            self._holidays = []
         else:
             self._holidays = self.holidays
 

--- a/businesstime/test/__init__.py
+++ b/businesstime/test/__init__.py
@@ -105,6 +105,10 @@ class BusinessTimeTest(unittest.TestCase):
         self.assertTrue(bd.isholiday(date(2014, 1, 1)))
         self.assertFalse(bd.isholiday(date(2014, 1, 2)))
 
+    def test_no_holidays(self):
+        bt = BusinessTime()
+        self.assertFalse(bt.isholiday(date(2014, 1, 1)))
+
     def test_businesstimedelta_after_during(self):
         start = datetime(2014, 1, 16, 18, 30)
         end = datetime(2014, 1, 22, 10, 0)


### PR DESCRIPTION
Fixes:

```
ERROR: test_no_holidays (businesstime.test.BusinessTimeTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "businesstime/businesstime/test/__init__.py", line 110, in test_no_holidays
    self.assertFalse(bt.isholiday(date(2014, 1, 1)))
  File "businesstime/businesstime/__init__.py", line 49, in isholiday
    return dt in self._holidays
AttributeError: 'BusinessTime' object has no attribute '_holidays'
```