### PR TITLE
added support for negative timedeltas

### DIFF
--- a/businesstime/__init__.py
+++ b/businesstime/__init__.py
@@ -120,6 +120,11 @@ class BusinessTime(object):
         Returns a datetime.timedelta with the number of full business days
         and business time between d1 and d2
         """
+
+        if d1 > d2:
+            d1, d2, timedelta_direction = d2, d1, -1
+        else:
+            timedelta_direction = 1 
         businessdays = self._build_spanning_datetimes(d1, d2)
         time = datetime.timedelta()
 
@@ -148,4 +153,4 @@ class BusinessTime(object):
                 count += 1
                 prev = current
 
-        return time
+        return time * timedelta_direction

--- a/businesstime/holidays/__init__.py
+++ b/businesstime/holidays/__init__.py
@@ -1,12 +1,14 @@
 import math
 import datetime
+import calendar
 
 
 class Holidays(object):
 
     rules = []
 
-    MONTH_LENGTHS = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+    def month_length(self, year,month):
+        return calendar.monthrange(year,month)[1]
 
     def _day_rule_matches(self, rule, dt):
         return dt.month == rule.get("month") and dt.day == rule.get("day")
@@ -17,7 +19,7 @@ class Holidays(object):
             if math.floor((dt.day - 1) / 7) == rule.get("week") - 1:
                 return True
             # Check for -week specification
-            length = self.MONTH_LENGTHS[dt.month]
+            length = self.month_length(dt.year,dt.month)
             if math.floor((length - dt.day) / 7) + 1 == rule.get("week") * -1:
                 return True
         return False

--- a/businesstime/test/__init__.py
+++ b/businesstime/test/__init__.py
@@ -254,3 +254,11 @@ class BusinessTimeTest(unittest.TestCase):
             self.bt.businesstimedelta(start, end),
             timedelta(days=1)
         )
+
+    def test_businesstimedelta_during_during_reverse(self):
+        end = datetime(2014, 1, 2, 9, 12)
+        start = datetime(2014, 1, 3, 9, 10)
+        self.assertEqual(
+            self.bt.businesstimedelta(start, end),
+            timedelta(hours=-7, minutes=-58)
+        )


### PR DESCRIPTION
This pull request adds support for negative time deltas. If the start time is after the end time, a negative value for time delta will be returned for the business time between the two time points.